### PR TITLE
Add the version on the interface protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This interface layer will set the following states, as appropriate:
     information, and is ready to serve as a KV store.
     The provided information can be accessed via the following methods:
       * `etcd.get_connection_string()`
+      * `etcd.get_version()`
   * `{relation_name}.tls.available` Etcd has provided the connection string
     information, and the tls client credentials to communicate with it.
     The client credentials can be accessed via:
@@ -50,7 +51,7 @@ This interface layer will set the following states, as appropriate:
     been related. The charm should call the following methods to provide the
     appropriate information to the clients:
 
-    * `{relation_name}.set_connection_string(string)`
+    * `{relation_name}.set_connection_string(string, version)`
     * `{relation_name}.set_client_credentials(key, cert, ca)`
 
 Example:

--- a/provides.py
+++ b/provides.py
@@ -36,7 +36,10 @@ class EtcdProvider(RelationBase):
         self.set_remote('client_ca', ca)
         self.set_remote('client_cert', cert)
 
-    def set_connection_string(self, connection_string):
+    def set_connection_string(self, connection_string, version=''):
         ''' Set the connection string on the global conversation for this
         relation. '''
+        # Note: Version added as a late-dependency for 2 => 3 migration
+        # If no version is specified, consumers should presume etcd 2.x
         self.set_remote('connection_string', connection_string)
+        self.set_remote('version', version)

--- a/requires.py
+++ b/requires.py
@@ -51,6 +51,10 @@ class EtcdClient(RelationBase):
         ''' Return the connection string, if available, or None. '''
         return self.get_remote('connection_string')
 
+    def get_version(self):
+        ''' Return the version of the etd protocol being used, or None. '''
+        return self.get_remote('version')
+
     def get_client_credentials(self):
         ''' Return a dict with the client certificate, ca and key to
         communicate with etcd using tls. '''


### PR DESCRIPTION
Its known that there are differences between etcd2 and etcd3. This
brings in the version to the connection_string communication exchange so
consumers can determine if a different path needs to be taken based on
the version connecting to.