### PR TITLE
Remove connected state when last unit departs

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -27,7 +27,9 @@ class EtcdProvider(RelationBase):
     @hook('{provides:etcd}-relation-{broken,departed}')
     def broken_or_departed(self):
         '''Remove connected state from the provides side of the relation. '''
-        self.remove_state('{relation_name}.connected')
+        conv = self.conversation()
+        if len(conv.units) == 1:
+            conv.remove_state('{relation_name}.connected')
 
     def set_client_credentials(self, key, cert, ca):
         ''' Set the client credentials on the global conversation for this


### PR DESCRIPTION
If units are removed the deployment may think it is disconnected from clients and so not reporting the right connection string. 

Fixes: https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/486